### PR TITLE
Support updating plugin status from within the engine

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.25",
+  "version": "0.10.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.25",
+  "version": "0.10.26",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -568,19 +568,21 @@ DynamicPlugin.prototype._connect = function() {
     }
     me.initializing = true;
     me._updateUI();
+    const engine_utils = {
+      __as_interface__: true,
+      __id__: me.config.id + "_utils",
+      terminatePlugin() {
+        me.terminate();
+      },
+      setPluginStatus(status) {
+        if (!me._disconnected) {
+          me.running = status.running;
+          me._updateUI();
+        }
+      },
+    };
     me.engine
-      .startPlugin(me.config, {
-        ...me._initialInterface,
-        terminatePlugin() {
-          me.terminate();
-        },
-        setPluginStatus(status) {
-          if (!me._disconnected) {
-            me.running = status.running;
-            me._updateUI();
-          }
-        },
-      })
+      .startPlugin(me.config, me._initialInterface, engine_utils)
       .then(remote => {
         // check if the plugin is terminated during startup
         if (!me.engine) {


### PR DESCRIPTION
This PR add a function `setPluginStatus` to allow the plugin engine to update the status of the plugin. For example `engine_utils.setPluginStatus({running: true})` will make the color of the plugin in red.

It also moves the terminate function from `config` to `engine_utils` and renamed it to `terminatePlugin` to be more explicit.


This fixes https://github.com/imjoy-team/ImJoy/issues/311 with https://github.com/imjoy-team/jupyter-engine-manager/pull/19 

@muellerflorian 