### PR TITLE
Clip long engine name for display

### DIFF
--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -69,7 +69,7 @@
             :key="engine.name"
           >
             <span class="md-list-item-content" style="cursor: pointer;">
-              <md-icon>sync_disabled</md-icon> {{ engine.name }}
+              <md-icon>sync_disabled</md-icon> {{ engine.name.slice(0, 20) }}
               <md-tooltip>Connect to {{ engine.name }} </md-tooltip>
               <md-button
                 v-if="!engine.connected"
@@ -77,9 +77,7 @@
                 @click.stop="removeEngine(engine)"
               >
                 <md-icon>delete_forever</md-icon>
-                <md-tooltip
-                  >Remove engine {{ engine.name.slice(0, 20) }}
-                </md-tooltip>
+                <md-tooltip>Remove engine {{ engine.name }} </md-tooltip>
               </md-button>
             </span>
           </md-menu-item>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -3386,8 +3386,9 @@ button.md-speed-dial-target {
 }
 
 #plugin-menu > .md-card-content {
-  max-height: calc(100vh - 95px - 86px);
-  overflow: auto;
+  max-height: calc(100vh - 95px - 66px);
+  overflow-y: auto;
+  overflow-x: hidden;
   padding-top: 5px;
   padding-left: 6px;
   padding-right: 6px;


### PR DESCRIPTION
If the engine name is too long, then the user won't be able to click the remove button. This PR clips the engine name to 20 letters if it's too long.

Fixes #326 