### PR TITLE
Improve show file dialog api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -985,23 +985,18 @@ It contains the following fields:
    you may want to define the path string as raw string using `r"xxxxxx"` syntax,
    we have encountered unrecognised path issue with normal strings.
   - **mode**: String. Modes for file selection. By default, the user can select a single or multiple file (with the `shift` key pressed)
-    - `single`: only a single file or directory can be selected. <!--**[TODO]** what's returned here?-->
+    - `single`: only a single file or directory can be selected.
     - `multiple`: multiple files or directories are selected and are returned in an array or list.
-    - `single|multiple` (default): both single and multiple selection are allowed. <!--**[TODO]** why this additional option?-->
-  - **uri_type**: String. Format of returned file path.
-    - `url` (default for JavaScript plugins): <!--**[TODO]**-->
-    - `path` (default for Python plugins): <!--**[TODO]**-->
+    - `single|multiple` (default): both single and multiple selection are allowed.
   - **file_manager**: String. Specify the file manager via url, in a `native-python` plugin for example, you can get the file manager URL via `api.FILE_MANAGER_URL`.
-  
-  - **hide_unselected**: If you specified file_manager, all other file managers will still show up and if you want to hide them, set `hide_unselected` to `true`.
 
 (Please also consult [this section](api?id=input-arguments) for how arguments can be set.)
 
 **Returns**
-* **ret**: Object (JavaScript) or dictionary (Python). Contains path or url and engine url as specified by `uri_type`.
-  - **path**: String or Array. It will be included for both `uri_type` (`'path'` or `'url'`). If multiple files are selected, it will be an array of paths.
-  - **url**: String or Array. Only available for `uri_type = 'url'`. If multiple files are selected, it will be an array of urls.
-  - **engine**: String. The engine url selected by the user.
+* **selected**: An array of object (JavaScript) or dictionary (Python). It can contain 0 to many selected file/directories. If the returned array is empty, it means the user did not select any file/directory. The file items in the array typically contains (depending on different file manager implementation):
+  - **path**: String. File path.
+  - **url**: String. URL to the file
+  - other fields.
 
 **Examples**
 
@@ -1010,9 +1005,9 @@ user canceled or that the plugin engine was not running.
 
 ```javascript
 
-const ret = await api.showFileDialog({root: '/', uri_type: 'url'})
-if(ret){
-  await api.alert("Selected file " + ret.url)
+const selected = await api.showFileDialog()
+if(selected.length>0){
+  await api.alert("Selected file " + selected[0].url)
 }
 else{
   await api.alert("User cancelled file selection.")
@@ -1021,7 +1016,7 @@ else{
 
 ```
 <!--**[TODO]: update this example to new api**-->
-[Try yourself >>](https://imjoy.io/#/app?plugin=imjoy-team/imjoy-demo-plugins:showFileDialog&w=examples)
+<!-- [Try yourself >>](https://imjoy.io/#/app?plugin=imjoy-team/imjoy-demo-plugins:showFileDialog&w=examples) -->
 
 
 ### api.showMessage

--- a/docs/development.md
+++ b/docs/development.md
@@ -1348,6 +1348,12 @@ Follow these steps, and you will be able to run ImJoy server and the plugin engi
 ## Change log
 
 ### API changes
+#### api_version: 0.1.8
+ * `api.showFileDialog`:
+   - if the file manager provide `showFileDialog` function, then ImJoy will use it.
+   - remove the key `uri_type` from input arguments, remove `engine` from its result.
+   - it will always return an array of items.
+
 #### api_version: 0.1.7
  * `api.fs` has been deprecated, the browser file system is moved to a separate plugin `BrowserFS`, to use the file system, you can do `const bfs_plugin = await api.getPlugin('BrowserFS'); const bfs = bfs_plugin.fs;`, now `fs` will be equivalent to `api.fs`. Notice: the data saved with `api.fs` will not be accessible with the new API, to get access the old data, please change `api_version` in the plugin config to `0.1.6`.
  * added `_rpcEncode` and `_rpcDecode` to support custom encoding and decoding

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2852,6 +2852,7 @@ export default {
     },
     async showFileDialog(_plugin, config) {
       config = config || {};
+      let _return_array = true;
       if (_plugin && _plugin.id) {
         if (!config.file_manager) {
           if (_plugin.api.FILE_MANAGER_URL) {
@@ -2884,16 +2885,38 @@ export default {
           config.return_object =
             config.return_object === undefined ? true : config.return_object;
         }
+
+        //TODO: remove this in the future
+        if (
+          _plugin.config.api_version &&
+          utils.compareVersions(_plugin.config.api_version, "<", "0.1.8")
+        ) {
+          _return_array = false;
+        }
       }
-      if (config.file_manager && config.file_manager.api.showFileDialog) {
-        return await config.file_manager.showFileDialog(config);
-      }
-      if (config.file_manager && config.hide_unselected) {
-        this.selected_file_managers = [config.file_manager];
+      let ret;
+
+      if (
+        _return_array &&
+        config.file_manager &&
+        config.file_manager.api.showFileDialog
+      ) {
+        ret = await config.file_manager.showFileDialog(config);
       } else {
-        this.selected_file_managers = this.fm.fileManagers;
+        if (config.file_manager && config.hide_unselected) {
+          this.selected_file_managers = [config.file_manager];
+        } else {
+          this.selected_file_managers = this.fm.fileManagers;
+        }
+        ret = this.$refs["file-dialog"].showDialog(_plugin, config);
       }
-      return this.$refs["file-dialog"].showDialog(_plugin, config);
+
+      if (_return_array) {
+        if (!ret) return [];
+        else if (!Array.isArray(ret)) return [ret];
+        else return ret;
+      }
+      return ret;
     },
     uploadFileToUrl(_plugin, config) {
       if (typeof config !== "object" || !config.file || !config.url) {

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2908,7 +2908,7 @@ export default {
         } else {
           this.selected_file_managers = this.fm.fileManagers;
         }
-        ret = this.$refs["file-dialog"].showDialog(_plugin, config);
+        ret = await this.$refs["file-dialog"].showDialog(_plugin, config);
       }
 
       if (_return_array) {

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -370,7 +370,7 @@
                 <template v-for="manager in fm.fileManagers">
                   <md-menu-item
                     v-if="manager.api && manager.api.showFileDialog"
-                    @click="manager.api.showFileDialog()"
+                    @click="showFileManagers(manager)"
                     :key="manager.url"
                     class="md-button"
                   >
@@ -2220,6 +2220,7 @@ export default {
         {
           loader_key: "Code Editor (file)",
           schema: ajv.compile({
+            type: "object",
             properties: {
               type: { type: "string" },
               name: {
@@ -2236,6 +2237,7 @@ export default {
         {
           loader_key: "Code Editor (url)",
           schema: ajv.compile({
+            type: "object",
             properties: {
               type: { type: "string", enum: ["imjoy/url"] },
               url: {
@@ -2253,6 +2255,7 @@ export default {
         {
           loader_key: "Image (file)",
           schema: ajv.compile({
+            type: "object",
             properties: {
               type: {
                 type: "string",
@@ -2267,6 +2270,7 @@ export default {
         {
           loader_key: "Image (url)",
           schema: ajv.compile({
+            type: "object",
             properties: {
               type: { type: "string", enum: ["imjoy/url"] },
               url: {
@@ -2464,10 +2468,11 @@ export default {
       this.status_text = info;
       this.$forceUpdate();
     },
-    showFileManagers() {
+    showFileManagers(file_manager) {
       this.showFileDialog(null, {
         uri_type: "url",
         root: "./",
+        file_manager: file_manager,
       })
         .then(selection => {
           if (this.screenWidth <= 800) {

--- a/web/src/plugins/iframeTemplate.imjoy.html
+++ b/web/src/plugins/iframeTemplate.imjoy.html
@@ -14,7 +14,7 @@
   "icon": "extension",
   "inputs": null,
   "outputs": null,
-  "api_version": "0.1.7",
+  "api_version": "0.1.8",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/src/plugins/nativePythonTemplate.imjoy.html
+++ b/web/src/plugins/nativePythonTemplate.imjoy.html
@@ -15,7 +15,7 @@
   "outputs": null,
   "flags": [],
   "icon": "extension",
-  "api_version": "0.1.7",
+  "api_version": "0.1.8",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/src/plugins/webPythonTemplate.imjoy.html
+++ b/web/src/plugins/webPythonTemplate.imjoy.html
@@ -15,7 +15,7 @@
   "outputs": null,
   "flags": [],
   "icon": "extension",
-  "api_version": "0.1.7",
+  "api_version": "0.1.8",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/src/plugins/webPythonWindowTemplate.imjoy.html
+++ b/web/src/plugins/webPythonWindowTemplate.imjoy.html
@@ -15,7 +15,7 @@
   "outputs": null,
   "flags": [],
   "icon": "extension",
-  "api_version": "0.1.7",
+  "api_version": "0.1.8",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/src/plugins/webWorkerTemplate.imjoy.html
+++ b/web/src/plugins/webWorkerTemplate.imjoy.html
@@ -14,7 +14,7 @@
   "icon": "extension",
   "inputs": null,
   "outputs": null,
-  "api_version": "0.1.7",
+  "api_version": "0.1.8",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/src/plugins/windowTemplate.imjoy.html
+++ b/web/src/plugins/windowTemplate.imjoy.html
@@ -14,7 +14,7 @@
   "icon": "extension",
   "inputs": null,
   "outputs": null,
-  "api_version": "0.1.7",
+  "api_version": "0.1.8",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/tests/testWebWorkerPlugin1.imjoy.html
+++ b/web/tests/testWebWorkerPlugin1.imjoy.html
@@ -12,7 +12,7 @@
     "op-ui-option2: {id: 'op-ui-option2', type: 'number', placeholder: 3}"
   ],
   "version": "0.1.0",
-  "api_version": "0.1.7",
+  "api_version": "0.1.8",
   "url": "",
   "description": "[TODO: describe this plugin with one sentence.]",
   "icon": "extension",

--- a/web/tests/testWebWorkerPlugin2.imjoy.html
+++ b/web/tests/testWebWorkerPlugin2.imjoy.html
@@ -9,7 +9,7 @@
   "tags": [],
   "ui": "",
   "version": "0.1.0",
-  "api_version": "0.1.7",
+  "api_version": "0.1.8",
   "url": "",
   "description": "[TODO: describe this plugin with one sentence.]",
   "icon": "extension",

--- a/web/tests/testWindowPlugin1.imjoy.html
+++ b/web/tests/testWindowPlugin1.imjoy.html
@@ -9,7 +9,7 @@
   "tags": [],
   "ui": "",
   "version": "0.1.0",
-  "api_version": "0.1.7",
+  "api_version": "0.1.8",
   "description": "[TODO: describe this plugin with one sentence.]",
   "icon": "extension",
   "inputs": null,


### PR DESCRIPTION
This PR make changes to the showFileDialog api, the following changes has been made:
   - if the file manager provide `showFileDialog` function, then ImJoy will use it.
   - remove the key `uri_type` from input arguments, remove `engine` from its result.
   - it will always return an array of items.

API version is bumped to 0.1.8

There should be no breaking change, the new behavior will only apply if a plugin has `api_version` >= 0.1.8.