### PR TITLE
Support base frame option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ To learn more details about ImJoy, please go to [ImJoy Docs](https://imjoy.io/do
 Currently, ImJoy consists of the following repositories:
  - [ImJoy Web App (core)](https://github.com/imjoy-team/ImJoy/) (this repository)
  - [ImJoy Plugin Engine](https://github.com/imjoy-team/imjoy-engine)
- - [ImJoy Desktop App](https://github.com/imjoy-team/imjoy-app)
  - [ImJoy Plugin Repository](https://github.com/imjoy-team/imjoy-plugins)
 
 ## Documentation, questions and feedback

--- a/docs/development.md
+++ b/docs/development.md
@@ -149,9 +149,7 @@ In Chrome for example, user can install ImJoy into [chrome://apps/](chrome://app
 You can run all the web plugins (`web-worker`, `window`, `web-python`) with the ImJoy App, however, for native plugins (`native-python`) you will need to connect to a plugin engine running locally or remotely.
 Here are the two options for installing the plugine engine:
 
-1. for basic users and desktop environments, the ImJoy Desktop App which includes the plugine engine can be downloaded [here](https://github.com/imjoy-team/imjoy-app/releases).
-
-2. for more advanced users and server environments, please download and install Anaconda or Miniconda with Python3, then run `pip install imjoy`. The plugin engine can then be launched through the `imjoy` command. More details are available [here](https://github.com/imjoy-team/imjoy-engine/).
+For running plugins with the plugin engine, please download and install Anaconda or Miniconda with Python3, then run `pip install imjoy`. The plugin engine can then be launched through the `imjoy --jupyter` command. More details are available [here](https://github.com/imjoy-team/imjoy-engine/).
 
 
 ## Plugin file format
@@ -479,9 +477,16 @@ To make the window in standalone mode by default (in full screen and detached fr
 
 If you want to show the window as a dialog, then set `"defaults": {"as_dialog": true}`.
 
+
+#### base_frame
+(**for window plugin only:**) defines a custom url to a html page which will be loaded in the window plugin.
+
+It is mendatory to include `<script src="https://lib.imjoy.io/static/jailed/_frame.js"></script>` in the base_frame html file (e.g. inside `<head>`), and this injected script will enable the communication between the window and the core of ImJoy.
+
+This option allows you load an existing html file as the window, but still connected to ImJoy and other plugins.
+
 #### runnable
 Defines whether the plugin can be executed by clicking on the plugin menu (By default, all plugins are `runnable`). For helper plugins which do not run by themselves, (e.g. a `native-python` plugin can be called by a `window` plugin and do not necessarily executed by the user directly), setting `"runnable": false` would move down the plugin to the bottom of the plugin menu and made non-clickable.
-
 
 ### `<docs>` block
 Contains the documentation of the plugin and is written in Markdown language.
@@ -1353,6 +1358,7 @@ Follow these steps, and you will be able to run ImJoy server and the plugin engi
    - if the file manager provide `showFileDialog` function, then ImJoy will use it.
    - remove the key `uri_type` from input arguments, remove `engine` from its result.
    - it will always return an array of items.
+ * support `base_frame` (in `<config>` block) option for `window` plugins to load from a custom html url.
 
 #### api_version: 0.1.7
  * `api.fs` has been deprecated, the browser file system is moved to a separate plugin `BrowserFS`, to use the file system, you can do `const bfs_plugin = await api.getPlugin('BrowserFS'); const bfs = bfs_plugin.fs;`, now `fs` will be equivalent to `api.fs`. Notice: the data saved with `api.fs` will not be accessible with the new API, to get access the old data, please change `api_version` in the plugin config to `0.1.6`.

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -113,7 +113,7 @@ Importantly, we are going to port the above code in our ImJoy plugin.
 ### Preperation
 Before start, you will need to install the ImJoy plugin engine accroding to the instructions here: https://github.com/imjoy-team/imjoy-engine , and we recommend to use Google Chrome or FireFox to perform the experiments (note: Safari won't work). 
 
-Once installed, you need to first start the plugin engine, either through the desktop if you installed, or run `imjoy` command if you chose the command line version of the plugin engine. Either way you will get a connection token string, which we will need to use to connect from the ImJoy web app.
+Once installed, you need to first start the plugin engine, either through the desktop if you installed, or run `imjoy --jupyter` command if you chose the command line version of the plugin engine. Either way you will get a connection token string, which we will need to use to connect from the ImJoy web app.
 
 Open Chrome or Firefox, go to https://imjoy.io and start ImJoy. Click the 🚀 icon in the upper-right corner to add the plugin engine by filling the connection token you got in the previous step.
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -54,16 +54,9 @@ plugin implementations, some plugins may still require internet access to functi
 
 ## Plugin Engine
 For more advanced processing, the **Python Plugin Engine** is required. The Plugin
-Engine allows to run native Python (`native-python`) plugins. We provide two ways
-to obtain this engine:
+Engine allows to run native Python (`native-python`) plugins. 
 
-1.  The plugin engine is included in the ImJoy Desktop App. After installing the
-    [Desktop App](https://github.com/imjoy-team/imjoy-app/releases), you can start the engine
-    with the button `START PLUGINE ENGINE`.
-    
-    ![imjoy-app-start-screen](assets/imjoy-app-start-screen.png ':size=400')
-
-2. You can download and install it with a command line script as described [here](https://github.com/imjoy-team/imjoy-engine).
+To obtain the plugin engine, you need to download and install it with a command line script as described [here](https://github.com/imjoy-team/imjoy-engine).
 
 Once you start the engine, it will automatically check for updates.
 
@@ -107,15 +100,6 @@ The nice thing about using telebit is that you will have a fixed URL. Alternativ
 
 ## FAQs
 
-### Plugin engine doesn't start (anymore)
-When the plugin engine doesn't start, performing an ImJoy upgrade often resolves this
-problem. For this, you can run the following command in your terminal:
-
-```bash
-export PATH=~/ImJoyApp/bin:$PATH
-pip install -U git+https://github.com/imjoy-team/imjoy-engine#egg=imjoy
-```
-
 ### Use existing Python
 This depends whether it's a conda-compatible distribution or not. Try to type `conda -V` command, if you see a version number(e.g:`conda 4.3.30`), it means you can skip the Anaconda/Miniconda installation, and install ImJoy directly with your existing Python.
 
@@ -133,7 +117,7 @@ secured website. So, you will have to switch to the offline version.
 
 Currently, the recommended way to use ImJoy on a remote computer:
  1. Login the remote server with SSH, start the plugin engine with
-    `python -m imjoy --serve --host=0.0.0.0`. The plugin engine will
+    `imjoy --jupyter --host=0.0.0.0`. The plugin engine will
     download a copy of ImJoy app and serve it through `http://YOUR_REMOTE_IP:9527`.
     In the meantime, it will give your a **connection token**, copy it from the
     terminal and you will need it in the next step.
@@ -144,9 +128,6 @@ Currently, the recommended way to use ImJoy on a remote computer:
     get when you start the engine.
 
 Also notice that, the ImJoy web app served from your plugin engine are completely isolated from the one from https://imjoy.io, meaning that the installed plugins, data are not shared.
-
-### Plugin engine error "address already in use"
-If you see something like this: `OSError: [Errno 48] error while attempting to bind on address ('127.0.0.1', 9527): address already in use`, It means you have another instance running which uses the port needed by the Plugin Engine. You need to find this instance  and kill that task if you don't known which one. For example, for port `9527`, you can run `lsof -n -i :9527 | grep LISTEN` in a terminal. This will list all process listening to the `9527` port, e.g. `+python3.6 1095 fmueller    7u  IPv4 0xb4b82ae29cbba843      0t0  TCP 127.0.0.1:http-alt (LISTEN)`. The process ID can be found directly after `python3.6`, in this case `1095`, you can then kill this process with `kill 1095`.
 
 ### CommandNotFoundError with 'conda activate'
 By default, ImJoy uses `conda activate` to activate conda environments if it's available. However, you may need to setup `conda activate` according to here: https://github.com/conda/conda/releases/tag/4.4.0

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy",
-  "version": "0.10.36",
+  "version": "0.10.37",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10297,9 +10297,9 @@
       "dev": true
     },
     "imjoy-core": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/imjoy-core/-/imjoy-core-0.11.12.tgz",
-      "integrity": "sha512-pa7rjBlomLFMXd2M4KWjLgfdUmU9yYCzYARWy7Aj46BxHL4+vlQQYHwBoSJtnljZI+oVniH1V1lGrybNz1FMxg==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/imjoy-core/-/imjoy-core-0.11.13.tgz",
+      "integrity": "sha512-uGOn/wF8XrdbBXqvKOhtSU1iLRES4mMblI3dmfVwxWi299c/PeXHOH4+txoDnGZRH/UpiO5O054qA8aYOSOheg==",
       "requires": {
         "ajv": "^6.9.1",
         "axios": "^0.18.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy",
-  "version": "0.10.36",
+  "version": "0.10.37",
   "private": false,
   "description": "ImJoy -- deep learning made easy.",
   "author": "imjoy-team <imjoy.team@gmail.com>",
@@ -33,7 +33,7 @@
     "axios": "^0.18.1",
     "dompurify": "^2.0.8",
     "file-saver": "^1.3.3",
-    "imjoy-core": "0.11.12",
+    "imjoy-core": "0.11.13",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",


### PR DESCRIPTION
This PR add support to start a window plugin from a custom html file url.

You can now specify the `base_frame` option in the `<config>` block in a `window` plugin. In the specified html file, you need to add `<script src="https://lib.imjoy.io/static/jailed/_frame.js"></script>`.

See here: https://github.com/imjoy-team/imjoy-core/pull/25

This PR also fixes part of the docs related to ImJoy Desktop App.