### PR TITLE
Bump imjoy-core version to 0.11.15

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy",
-  "version": "0.10.37",
+  "version": "0.10.38",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10297,9 +10297,9 @@
       "dev": true
     },
     "imjoy-core": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/imjoy-core/-/imjoy-core-0.11.14.tgz",
-      "integrity": "sha512-cDjOZk8tvxkiRvbZ8Y0SP56FRMRBHj8zlWhyY4IdsE1IRuknSUaQ7vZtlVNlwNveeBeb6LyAZBk4ynl/lyOkOA==",
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/imjoy-core/-/imjoy-core-0.11.15.tgz",
+      "integrity": "sha512-Oz/fNN/DymnMzy6zqqvL4Qp7Z4L4KZP1j+38Vbl2TvQluVAGg47Q/C9vwQO525uCnywZgzVSJEM47xygkgs/rA==",
       "requires": {
         "ajv": "^6.9.1",
         "axios": "^0.18.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy",
-  "version": "0.10.37",
+  "version": "0.10.38",
   "private": false,
   "description": "ImJoy -- deep learning made easy.",
   "author": "imjoy-team <imjoy.team@gmail.com>",
@@ -33,7 +33,7 @@
     "axios": "^0.18.1",
     "dompurify": "^2.0.8",
     "file-saver": "^1.3.3",
-    "imjoy-core": "0.11.14",
+    "imjoy-core": "0.11.15",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",


### PR DESCRIPTION
This PR upgrade imjoy-core to 0.11.15 to with bug fix for the imjoy-loader.

This allows using web app directly within ImJoy, for example: 
```html
<script lang="python">
from imjoy import api
import numpy as np

class ImJoyPlugin():
    def setup(self):
        api.log('initialized')

    async def run(self, ctx):
        image_array = np.random.randint(0, 255, [100, 100], dtype='uint8')
        p = await api.showDialog(type="external", src="https://oeway.github.io/itk-vtk-viewer/", data={"image_array": image_array})
        # you can also call the imshow api
        # p.imshow(image_array)

api.export(ImJoyPlugin())
</script>
```