### PR TITLE
Support #ShutDownSTEM: Change background color to black!

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -167,10 +167,10 @@
   <body>
     <div id="welcome-page">
       <a href="https://github.com/imjoy-team/ImJoy" class="github-corner" aria-label="View source on Github"><svg viewBox="0 0 250 250" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
-      <section class="cover show" style="background: rgb(209, 220, 239);">
+      <section class="cover show" style="background: rgb(0, 0, 0);">
         <div class="cover-main"><!-- _coverpage.md -->
           <p> <img src="/static/img/imjoy-logo-black.svg?sanitize=true" width="380" /></p>
-          <h1>Deep Learning Made Easy!</h1>
+          <h1 style="color:white!important;">We support [#ShutDownSTEM](https://www.shutdownstem.com/)!</h1>
           <img src="/static/img/loader.gif" class="loading-img"></img>
           <p>
             <a href="https://rdcu.be/bYbGO" target="_blank">Publication</a>
@@ -182,10 +182,10 @@
         <div class="mask"></div>
       </section>
     </div>
-    <section id="loading-imjoy-section" class="cover show" style="background: rgb(209, 220, 239);">
+    <section id="loading-imjoy-section" class="cover show" style="background: rgb(0, 0, 0);">
       <div class="cover-main">
-        <p> <img src="/static/img/imjoy-logo-black.svg?sanitize=true" width="380" /></p>
-        <h1>Deep Learning Made Easy!</h1>
+        <p> <img src="/static/img/imjoy-logo-white.svg?sanitize=true" width="380" /></p>
+        <h1 style="color:white!important;">We support <a style="display: inline!important;" target="_blank" href="https://www.shutdownstem.com/">#ShutDownSTEM</a></h1>
         <img src="/static/img/loader.gif" class="loading-img"></img>
       </div>
       <div class="mask"></div>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -167,10 +167,18 @@
   <body>
     <div id="welcome-page">
       <a href="https://github.com/imjoy-team/ImJoy" class="github-corner" aria-label="View source on Github"><svg viewBox="0 0 250 250" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
-      <section class="cover show" style="background: rgb(0, 0, 0);">
+      <section class="cover show" style="background: rgb(0, 0, 0)!important;">
         <div class="cover-main"><!-- _coverpage.md -->
-          <p> <img src="/static/img/imjoy-logo-black.svg?sanitize=true" width="380" /></p>
-          <h1 style="color:white!important;">We support [#ShutDownSTEM](https://www.shutdownstem.com/)!</h1>
+          <p> <img src="/static/img/imjoy-logo-white.svg?sanitize=true" width="380" /></p>
+          <h1 style="color:white!important;">
+            We support
+            <a
+              style="display: inline!important;"
+              target="_blank"
+              href="https://www.shutdownstem.com/"
+              >#ShutDownSTEM</a
+            >!
+          </h1>
           <img src="/static/img/loader.gif" class="loading-img"></img>
           <p>
             <a href="https://rdcu.be/bYbGO" target="_blank">Publication</a>

--- a/web/src/components/Home.vue
+++ b/web/src/components/Home.vue
@@ -18,17 +18,25 @@
           class="octo-body"
         ></path></svg
     ></a>
-    <section class="cover show" style="background: rgb(209, 220, 239);">
+    <section class="cover show" style="background: black!important;">
       <div id="particles-js"></div>
       <div class="cover-main">
         <!-- _coverpage.md -->
         <p>
           <img
-            src="/static/img/imjoy-logo-black.svg?sanitize=true"
+            src="/static/img/imjoy-logo-white.svg?sanitize=true"
             width="380"
           />
         </p>
-        <h1>Deep Learning Made Easy!</h1>
+        <h1 style="color:white!important;">
+          We support
+          <a
+            style="display: inline!important;"
+            target="_blank"
+            href="https://www.shutdownstem.com/"
+            >#ShutDownSTEM</a
+          >!
+        </h1>
         <p class="badges">
           <a href="https://github.com/imjoy-team/ImJoy" target="_blank"
             ><img


### PR DESCRIPTION
This PR changes the background of the home page to black to support the current [#ShutDownSTEM](https://www.shutdownstem.com/) strike. 

To be inline with our [Code of Conduct](https://github.com/imjoy-team/ImJoy/blob/master/docs/CODE_OF_CONDUCT.md), we take the responsibility to spread the value and make our society more inclusive.