### PR TITLE
Support docs config

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -282,6 +282,12 @@ URL for the plugin project repository
 #### website
 URL for the plugin project website
 
+#### docs
+URL for the plugin documentation, either to a markdown file (e.g. raw Github URL ends with `.md`),
+or a any web page. 
+
+Note: if you also provide a `<docs>` block, then this field will be ignored.
+
 #### tags
 List of supported tags which configures the plugin after installed. 
 
@@ -510,6 +516,9 @@ Defines whether the plugin can be executed by clicking on the plugin menu (By de
 Contains the documentation of the plugin and is written in Markdown language.
 Please consulte this document for an introduction to [Markdown](https://guides.github.com/features/mastering-markdown/).
 Please note that if you provide links that these will be opened in another tab, leaving the ImJoy instance running.
+
+Optionally, you can also skip the `<docs>` block, but pass a url to the `docs` field in `<config>`.
+The content at the url can be a markdown file or a regular web page.
 
 ### `<window>` block
 Defines the HTML code for the display in the plugin window.

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,7 @@
     "axios": "^0.18.1",
     "dompurify": "^2.0.8",
     "file-saver": "^1.3.3",
-    "imjoy-core": "0.13.22",
+    "imjoy-core": "0.13.23",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2549,9 +2549,35 @@ export default {
         console.error("permission handler not found.");
       }
     },
-    showDoc(pid) {
+    async showDoc(pid) {
       const plugin = this.pm.plugins[pid];
       const pconfig = plugin.config;
+      let source;
+      if (pconfig.docs && typeof pconfig.docs === "string") {
+        if (pconfig.docs.startsWith("http") && pconfig.docs.endsWith(".md")) {
+          try {
+            const response = await axios.get(pconfig.docs);
+            if (!response || !response.data) {
+              alert("failed to get plugin documentation from " + pconfig.docs);
+              return;
+            }
+            source = response.data;
+          } catch (e) {
+            alert(
+              "failed to get plugin documentation from " +
+                pconfig.docs +
+                ":" +
+                e.toString()
+            );
+            return;
+          }
+        } else {
+          this.createWindow({ src: pconfig.docs });
+          return;
+        }
+      } else {
+        source = pconfig && pconfig.docs && pconfig.docs.content;
+      }
       const w = {
         name: "About " + pconfig.name,
         type: "imjoy/markdown",
@@ -2562,7 +2588,7 @@ export default {
           name: pconfig.name,
           id: plugin.id,
           plugin_info: pconfig,
-          source: pconfig && pconfig.docs[0] && pconfig.docs[0].content,
+          source: source,
         },
       };
       this.createWindow(w);


### PR DESCRIPTION
This PR allows setting `docs` field in the `<config>` as an alternative way of specifying documentation to the `<docs>` field, this is necessary for independent imjoy-rpc web app.

The `docs` field can be used to specify a url that point to a raw github url to a markdown file or a web page.

@muellerflorian 