### PR TITLE
Upgrade core to 0.13.55: fix gist url bug

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy",
-  "version": "0.11.25",
+  "version": "0.11.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12430,9 +12430,9 @@
       "dev": true
     },
     "imjoy-core": {
-      "version": "0.13.54",
-      "resolved": "https://registry.npmjs.org/imjoy-core/-/imjoy-core-0.13.54.tgz",
-      "integrity": "sha512-nhA+nsTwSBGk+9b+HeZL8FwPskLwxxyy8csF/rWQuZL/DJFR6LwkBs1zqS4dilVx6PgCeZj+9HN5TVufWKC4FA==",
+      "version": "0.13.55",
+      "resolved": "https://registry.npmjs.org/imjoy-core/-/imjoy-core-0.13.55.tgz",
+      "integrity": "sha512-s0howha7uYjVXxbwiDW9DqvVhGygcckl0m1OcXu5be9UWAX9DD10oyuAjT2a6CG7ydANBbgEW9Otzam2pKGP9A==",
       "requires": {
         "ajv": "^6.9.1",
         "axios": "^0.18.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy",
-  "version": "0.11.25",
+  "version": "0.11.26",
   "private": false,
   "description": "ImJoy -- deep learning made easy.",
   "author": "imjoy-team <imjoy.team@gmail.com>",
@@ -33,7 +33,7 @@
     "axios": "^0.18.1",
     "dompurify": "^2.0.8",
     "file-saver": "^1.3.3",
-    "imjoy-core": "0.13.54",
+    "imjoy-core": "0.13.55",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",


### PR DESCRIPTION
This is a fix for api.createWindow fails with gist url.